### PR TITLE
Fix for scroll "banding" borders due to fraction-pixel rendering

### DIFF
--- a/square/scroll.js
+++ b/square/scroll.js
@@ -84,8 +84,8 @@ Game._drawLayer = function (layer) {
     var endCol = startCol + (this.camera.width / map.tsize);
     var startRow = Math.floor(this.camera.y / map.tsize);
     var endRow = startRow + (this.camera.height / map.tsize);
-    var offsetX = -this.camera.x + startCol * map.tsize;
-    var offsetY = -this.camera.y + startRow * map.tsize;
+    var offsetX = Math.round( -this.camera.x + startCol * map.tsize );
+    var offsetY = Math.round( -this.camera.y + startRow * map.tsize );
 
     for (var c = startCol; c <= endCol; c++) {
         for (var r = startRow; r <= endRow; r++) {


### PR DESCRIPTION
On some browsers the floating point part of the camera position causes weird "banding"/borders (see [here](https://www.dropbox.com/s/f3ih01vuhyldfu4/Snapchat-8101245029473490274.mp4)), which could be most easily overcome by pixel snapping.

Pixel-snapping should most of the time happen while drawing, but since other components are integers, it could be used on the `offsetX`/`offsetY` vars directly.
